### PR TITLE
Simple configuration for extra columns

### DIFF
--- a/config/development.json
+++ b/config/development.json
@@ -4,5 +4,13 @@
     "exchange": "DLX"
   },
   "dlxQueue": "dead-letter-manual",
-  "routingKeyHeader": "x-routing-key"
+  "routingKeyHeader": "x-routing-key",
+  "clientConfig": {
+    "extraCols": [
+      {
+        "text": "Error",
+        "key": "errors"
+      }
+    ]
+  }
 }

--- a/config/test.json
+++ b/config/test.json
@@ -14,7 +14,13 @@
   "dlxQueue": "dead-letter-manual-test",
   "clientConfig": {
     "correlationIdUrlPrefix": "http://prefix/",
-    "correlationIdUrlSuffix": "/suffix"
+    "correlationIdUrlSuffix": "/suffix",
+    "extraCols": [
+      {
+        "text": "Error",
+        "key": "errors"
+      }
+    ]
   },
   "trello": {
     "apiKey": "some-api-key",

--- a/lib/client/App.jsx
+++ b/lib/client/App.jsx
@@ -237,6 +237,19 @@ export default class App extends React.Component {
     if (window.config.trello) {
       columns.push({text: "Trello", dataField: "trello", sort: true, formatter: this.trelloFormatter, editable: false});
     }
+
+    if (window.config.extraCols && window.config.extraCols.length) {
+      window.config.extraCols.forEach((colConf) => {
+        columns.push({
+          text: colConf.text,
+          dataField: "message",
+          formatter: (message) => {
+            return JSON.stringify(message[colConf.key]);
+          },
+          editable: false
+        });
+      });
+    }
     const selectRowProp = {
       clickToExpand: true,
       selected: this.state.selected,


### PR DESCRIPTION
Adds possibility to configure extra columns.

Very basic first iteration where it is possible to configure extra columns with custom name and specify which key from the message to display in the column.

Only supports keys at first level on the message.

Trying to make tests more stable.