### PR TITLE
Introduce dark mode

### DIFF
--- a/lib/client/App.jsx
+++ b/lib/client/App.jsx
@@ -33,6 +33,7 @@ import "bootstrap/dist/css/bootstrap.min.css";
 //import Popper from "popper.js";
 import "bootstrap/dist/js/bootstrap.bundle.min";
 import "react-bootstrap-table-next/dist/react-bootstrap-table2.min.css";
+import "./app.css";
 import BootstrapTable from "react-bootstrap-table-next";
 import cellEditFactory from "react-bootstrap-table2-editor";
 import filterFactory, {textFilter} from "react-bootstrap-table2-filter";
@@ -49,7 +50,8 @@ export default class App extends React.Component {
     super();
     this.state = {
       data: {},
-      selected: []
+      selected: [],
+      darkMode: window.matchMedia && window.matchMedia("(prefers-color-scheme: dark)").matches
     };
   }
 
@@ -257,7 +259,7 @@ export default class App extends React.Component {
       selected: this.state.selected,
       onSelect: this.handleOnSelect,
       onSelectAll: this.handleOnSelectAll,
-      bgColor: "#00BFFF",
+      bgColor: this.state.darkMode ? "#d2992226" : "#00BFFF",
       mode: "checkbox" // single row selection
     };
 
@@ -276,6 +278,7 @@ export default class App extends React.Component {
               onEdit={(o) => this.handleMessageEdit(o, row.id)}
               onAdd={(o) => this.handleMessageEdit(o, row.id)}
               onDelete={(o) => this.handleMessageEdit(o, row.id)}
+              theme={this.state.darkMode ? "twilight" : "rjv-default"}
             />
           </div>
         );
@@ -323,16 +326,16 @@ export default class App extends React.Component {
           selectRow={selectRowProp}
           expandRow={expandRow}
           filter={filterFactory()}
-          headerClasses="thead-light"
+          classes={this.state.darkMode ? "table-dark" : "table-light-bordered"}
         />
-        <div className="btn-toolbar" role="toolbar" aria-label="Toolbar with button groups">
+        <div className="btn-toolbar mb-2" role="toolbar" aria-label="Toolbar with button groups">
           <div className="btn-group mr-2" role="group" aria-label="First group">
             <button className="btn btn-primary" onClick={this.handleBtnClickResend}>
               Resend
             </button>
           </div>
-          <div className="btn-group mr-2" role="group" aria-label="Secondary group">
-            <button className="btn btn-secondary" onClick={this.handleBtnClickDelete}>
+          <div className="btn-group mr-2 ml-4" role="group" aria-label="Secondary group">
+            <button className="btn btn-danger" onClick={this.handleBtnClickDelete}>
               Delete
             </button>
           </div>

--- a/lib/client/app.css
+++ b/lib/client/app.css
@@ -1,5 +1,11 @@
-body {
-  font-family: "HelveticaNeue-Light", "Helvetica Neue Light", "Helvetica Neue", Helvetica, Arial, "Lucida Grande", sans-serif;
-  font-weight: 300;
-  font-size: 14px;
+@media (prefers-color-scheme: dark) {
+  body {
+    background: #343a40;
+  }
+  .d-flex a, .d-flex h1 {
+    color: #ffffff;
+  }
+  .react-json-view {
+    background: none !important;
+  }
 }

--- a/test/end-to-end.js
+++ b/test/end-to-end.js
@@ -314,8 +314,8 @@ Feature("dlx-web", () => {
       await page.waitForSelector(".table > tbody > tr > td > .selection-input-4");
       await page.click(".table > tbody > tr > td > .selection-input-4");
       // click delete
-      await page.waitForSelector("#root > div > .btn-toolbar > .btn-group > .btn-secondary");
-      await page.click("#root > div > .btn-toolbar > .btn-group > .btn-secondary");
+      await page.waitForSelector("#root > div > .btn-toolbar > .btn-group > .btn-danger");
+      await page.click("#root > div > .btn-toolbar > .btn-group > .btn-danger");
     });
 
     Then("the message should be gone", async () => {
@@ -392,8 +392,8 @@ Feature("dlx-web", () => {
       // select all
       await page.click("#root > div > div:nth-child(2) > table > thead > tr > th:nth-child(1) > input");
       // click delete
-      await page.waitForSelector("#root > div > .btn-toolbar > .btn-group > .btn-secondary");
-      await page.click("#root > div > .btn-toolbar > .btn-group > .btn-secondary");
+      await page.waitForSelector("#root > div > .btn-toolbar > .btn-group > .btn-danger");
+      await page.click("#root > div > .btn-toolbar > .btn-group > .btn-danger");
     });
 
     Then("the foo message should be gone", async () => {
@@ -486,8 +486,8 @@ Feature("dlx-web", () => {
       await page.waitForSelector(".table > tbody > tr > td > .selection-input-4");
       await page.click(".table > tbody > tr > td > .selection-input-4");
       // click delete
-      await page.waitForSelector("#root > div > .btn-toolbar > .btn-group > .btn-secondary");
-      await page.click("#root > div > .btn-toolbar > .btn-group > .btn-secondary");
+      await page.waitForSelector("#root > div > .btn-toolbar > .btn-group > .btn-danger");
+      await page.click("#root > div > .btn-toolbar > .btn-group > .btn-danger");
     });
 
     after((done) => {
@@ -578,8 +578,8 @@ Feature("dlx-web", () => {
       await page.waitForSelector(".table > tbody > tr > td > .selection-input-4");
       await page.click(".table > tbody > tr > td > .selection-input-4");
       // click delete
-      await page.waitForSelector("#root > div > .btn-toolbar > .btn-group > .btn-secondary");
-      await page.click("#root > div > .btn-toolbar > .btn-group > .btn-secondary");
+      await page.waitForSelector("#root > div > .btn-toolbar > .btn-group > .btn-danger");
+      await page.click("#root > div > .btn-toolbar > .btn-group > .btn-danger");
     });
 
     after((done) => {


### PR DESCRIPTION
- Remove not used styles in app.css and actually include it
- Add media query for detecting preferred dark mode and adapt background, links etc
- Set a state prop `darkMode` that can be used to determine classes when rendering components
- Set BootstrapTable to table-dark if dark mode
- Set ReactJson to a dark theme if dark mode (the theme background is overrided in the css to match the table)
- Change the delete button to be red both in dark and light mode and make some space between the buttons


Here is a preview of dark mode

<img width="1920" alt="darkmode" src="https://user-images.githubusercontent.com/10448878/110849986-a095ed80-82af-11eb-8b26-4a80fcc87e48.png">
